### PR TITLE
Level-Up Moveset Update

### DIFF
--- a/data/pokemon/evos_attacks_johto.asm
+++ b/data/pokemon/evos_attacks_johto.asm
@@ -553,10 +553,11 @@ SpinarakEvosAttacks:
 	dbw 1, POISON_STING
 	dbw 1, STRING_SHOT
 	dbw 5, SCARY_FACE
-	dbw 9, CONSTRICT
+	dbw 8, CONSTRICT
+	dbw 11, LEECH_LIFE
 	dbw 14, BITE ; SW97
 	dbw 18, NIGHT_SHADE
-	dbw 22, LEECH_LIFE
+	dbw 22, FURY_CUTTER ; TM
 	dbw 28, FURY_SWIPES
 	dbw 32, CONFUSION ; SW97
 	dbw 37, SPIDER_WEB
@@ -571,10 +572,11 @@ AriadosEvosAttacks:
 	dbw 1, POISON_STING
 	dbw 1, STRING_SHOT
 	dbw 5, SCARY_FACE
-	dbw 9, CONSTRICT
+	dbw 8, CONSTRICT
+	dbw 11, LEECH_LIFE
 	dbw 14, BITE ; SW97
 	dbw 18, NIGHT_SHADE
-	dbw 22, LEECH_LIFE
+	dbw 22, FURY_CUTTER ; TM
 	dbw 30, FURY_SWIPES
 	dbw 34, CONFUSION ; SW97
 	dbw 39, SPIDER_WEB
@@ -618,7 +620,7 @@ CrobatEvosAttacks:
 	dbw 31, THRASH ; RG proto
 	dbw 37, CONFUSION ; RG proto
 	dbw 41, MEAN_LOOK
-	dbw 49, WIND_RIDE
+	dbw 49, MEGA_DRAIN ; RBY TM
 	dbw 56, HAZE
 	dbw 60, MOONLIGHT ; SW97
 	db 0 ; no more level-up moves
@@ -846,10 +848,10 @@ MareepEvosAttacks:
 	dbw 12, TAIL_WHIP ; SW97
 	dbw 16, THUNDER_WAVE
 	dbw 22, COTTON_SPORE
-	dbw 28, SWIFT ; SW97
-	dbw 34, LIGHT_SCREEN
+	dbw 28, THUNDERBOLT ; SW97
+	dbw 34, SWIFT ; SW97
 	dbw 38, DAZZLING_GLEAM ; SV
-	dbw 42, THUNDERBOLT ; SW97
+	dbw 42, LIGHT_SCREEN
 	dbw 46, HYPNOSIS ; SW97
 	dbw 52, THUNDER
 	db 0 ; no more level-up moves
@@ -863,10 +865,10 @@ FlaaffyEvosAttacks:
 	dbw 12, TAIL_WHIP ; SW97
 	dbw 18, THUNDER_WAVE
 	dbw 24, COTTON_SPORE
-	dbw 30, SWIFT ; SW97
-	dbw 38, LIGHT_SCREEN
+	dbw 30, THUNDERBOLT ; SW97
+	dbw 38, SWIFT ; SW97
 	dbw 42, DAZZLING_GLEAM ; SV
-	dbw 46, THUNDERBOLT ; SW97
+	dbw 46, LIGHT_SCREEN
 	dbw 52, HYPNOSIS ; SW97
 	dbw 58, THUNDER
 	db 0 ; no more level-up moves
@@ -879,10 +881,10 @@ AmpharosEvosAttacks:
 	dbw 12, TAIL_WHIP ; SW97
 	dbw 18, THUNDER_WAVE
 	dbw 24, COTTON_SPORE
-	dbw 30, SWIFT ; SW97
-	dbw 40, LIGHT_SCREEN
+	dbw 30, THUNDERBOLT ; SW97
+	dbw 40, SWIFT ; SW97
 	dbw 44, DAZZLING_GLEAM ; SV
-	dbw 48, THUNDERBOLT ; SW97
+	dbw 48, LIGHT_SCREEN
 	dbw 56, HYPNOSIS ; SW97
 	dbw 62, THUNDER
 	db 0 ; no more level-up moves
@@ -956,7 +958,7 @@ BonslyEvosAttacks:
 	dbw 29, ROCK_SLIDE
 	dbw 35, SLAM
 	dbw 41, DOUBLE_EDGE ; FRLG
-	dbw 47, UPROOT
+	dbw 47, SUBSTITUTE ; NYPC
 	dbw 52, COUNTER ; FRLG move tutor
 	db 0 ; no more level-up moves
 
@@ -971,7 +973,7 @@ SudowoodoEvosAttacks:
 	dbw 31, ROCK_SLIDE
 	dbw 39, SLAM
 	dbw 45, DOUBLE_EDGE ; FRLG
-	dbw 53, UPROOT
+	dbw 53, SUBSTITUTE ; NYPC
 	dbw 58, COUNTER ; FRLG move tutor
 	db 0 ; no more level-up moves
 
@@ -1004,7 +1006,7 @@ HoppipEvosAttacks:
 	dbw 35, GROWTH ; SW97
 	dbw 39, RAZOR_LEAF ; SW97
 	dbw 45, COTTON_SPORE
-	dbw 50, WIND_RIDE
+	dbw 50, GIGA_DRAIN ; HGSS
 	db 0 ; no more level-up moves
 
 SkiploomEvosAttacks:
@@ -1025,7 +1027,7 @@ SkiploomEvosAttacks:
 	dbw 39, GROWTH ; SW97
 	dbw 43, RAZOR_LEAF ; SW97
 	dbw 49, COTTON_SPORE
-	dbw 56, WIND_RIDE
+	dbw 56, GIGA_DRAIN ; HGSS
 	db 0 ; no more level-up moves
 
 JumpluffEvosAttacks:
@@ -1045,7 +1047,7 @@ JumpluffEvosAttacks:
 	dbw 41, GROWTH ; SW97
 	dbw 47, RAZOR_LEAF ; SW97
 	dbw 53, COTTON_SPORE
-	dbw 60, WIND_RIDE
+	dbw 60, GIGA_DRAIN ; HGSS
 	db 0 ; no more level-up moves
 
 AipomEvosAttacks:
@@ -1191,7 +1193,7 @@ YanmaEvosAttacks:
 	dbw 39, DETECT
 	dbw 43, SWIFT
 	dbw 48, PURSUIT ; HGSS
-	dbw 52, WIND_RIDE
+	dbw 52, DOUBLE_EDGE ; FRLG tutor
 	dbw 56, SCREECH
 	db 0 ; no more level-up moves
 	
@@ -1209,7 +1211,7 @@ YanmegaEvosAttacks:
 	dbw 41, DETECT
 	dbw 45, SWIFT
 	dbw 50, PURSUIT ; HGSS
-	dbw 56, WIND_RIDE
+	dbw 56, DOUBLE_EDGE ; FRLG tutor
 	dbw 60, SCREECH
 	dbw 65, SLASH
 	db 0 ; no more level-up moves
@@ -1230,7 +1232,7 @@ OniyanmaEvosAttacks:
 	dbw 41, DETECT
 	dbw 45, SWIFT
 	dbw 50, PURSUIT ; HGSS
-	dbw 56, WIND_RIDE
+	dbw 56, DOUBLE_EDGE ; FRLG tutor
 	dbw 60, SCREECH
 	dbw 65, THUNDER
 	db 0 ; no more level-up moves
@@ -1761,6 +1763,7 @@ ScizorEvosAttacks:
 	dbw 42, SWORDS_DANCE
 	dbw 48, DOUBLE_TEAM
 	dbw 54, CROSS_CUTTER
+	dbw 60, STEEL_WING
 	db 0 ; no more level-up moves
 
 ShuckleEvosAttacks:
@@ -1835,7 +1838,7 @@ TeddiursaEvosAttacks:
 	dbw 31, SLASH
 	dbw 37, MOONLIGHT ; from BM Ursaluna
 	dbw 43, SNORE
-	dbw 47, UPROOT
+	dbw 47, BODY_SLAM ; FRLG tutor
 	dbw 51, THRASH
 	dbw 55, PLAY_ROUGH ; PLA
 	dbw 59, DOUBLE_EDGE ; PLA
@@ -1853,7 +1856,7 @@ UrsaringEvosAttacks:
 	dbw 33, SLASH
 	dbw 39, MOONLIGHT ; from BM Ursaluna
 	dbw 45, SNORE
-	dbw 51, UPROOT
+	dbw 51, BODY_SLAM ; FRLG tutor
 	dbw 55, THRASH
 	dbw 59, PLAY_ROUGH ; PLA
 	dbw 65, DOUBLE_EDGE ; PLA
@@ -1870,7 +1873,7 @@ UrsalunaEvosAttacks:
 	dbw 33, SLASH
 	dbw 39, MOONLIGHT
 	dbw 45, SNORE
-	dbw 51, UPROOT
+	dbw 51, BODY_SLAM
 	dbw 55, THRASH
 	dbw 59, PLAY_ROUGH
 	dbw 65, DOUBLE_EDGE
@@ -2189,7 +2192,7 @@ PhanpyEvosAttacks:
 	dbw 26, STOMP ; SW97
 	dbw 31, TAKE_DOWN
 	dbw 35, PROTECT ; SW97
-	dbw 40, UPROOT
+	dbw 40, BODY_SLAM ; FRLG tutor
 	dbw 44, ENDURE
 	dbw 49, RAPID_SPIN ; from Donphan
 	dbw 55, DOUBLE_EDGE
@@ -2208,7 +2211,7 @@ DonphanEvosAttacks:
 	dbw 28, STOMP ; SW97
 	dbw 33, TAKE_DOWN ; from Phanpy
 	dbw 37, PROTECT ; SW97
-	dbw 44, UPROOT
+	dbw 44, BODY_SLAM ; FRLG tutor
 	dbw 48, ENDURE ; from Phanpy
 	dbw 53, RAPID_SPIN
 	dbw 61, DOUBLE_EDGE ; from Phanpy
@@ -2455,8 +2458,8 @@ SoneggEvosAttacks:
 	dbw 32, ENCORE
 	dbw 38, MIRROR_MOVE
 	dbw 44, EGG_BOMB
-	dbw 50, WIND_RIDE
-	dbw 56, DOUBLE_EDGE
+	dbw 50, DOUBLE_EDGE
+	dbw 56, SKY_ATTACK
 	db 0 ; no more level-up moves
 
 CacawphonyEvosAttacks:
@@ -2472,8 +2475,8 @@ CacawphonyEvosAttacks:
 	dbw 34, ENCORE
 	dbw 40, MIRROR_MOVE
 	dbw 48, EGG_BOMB
-	dbw 54, WIND_RIDE
-	dbw 60, DOUBLE_EDGE
+	dbw 54, DOUBLE_EDGE
+	dbw 60, SKY_ATTACK
 	db 0 ; no more level-up moves
 
 TrebirEvosAttacks:
@@ -2489,8 +2492,8 @@ TrebirEvosAttacks:
 	dbw 34, ENCORE
 	dbw 40, MIRROR_MOVE
 	dbw 48, EGG_BOMB
-	dbw 54, WIND_RIDE
-	dbw 60, HEAL_BELL
+	dbw 54, HEAL_BELL
+	dbw 60, SKY_ATTACK
 	db 0 ; no more level-up moves
 
 SakurazeEvosAttacks:
@@ -2512,15 +2515,18 @@ TanobiEvosAttacks:
 	dbw 1, UPPERCUT
 	dbw 1, LEER
 	dbw 7, QUICK_ATTACK
-	dbw 12, ROLLING_KICK
-	dbw 18, AGILITY
-	dbw 23, SWIFT
-	dbw 28, JUMP_KICK
-	dbw 32, DETECT
-	dbw 36, SPIKES
-	dbw 41, METAL_CLAW
-	dbw 47, SLASH
-	dbw 53, HI_JUMP_KICK
+	dbw 11, ROLLING_KICK
+	dbw 15, AGILITY
+	dbw 20, WING_ATTACK
+	dbw 24, SWIFT
+	dbw 29, JUMP_KICK
+	dbw 33, METAL_CLAW
+	dbw 37, SLASH
+	dbw 41, SPIKES
+	dbw 46, FURY_CUTTER
+	dbw 52, DETECT
+	dbw 56, HI_JUMP_KICK
+	dbw 61, CROSS_CHOP
 	db 0 ; no more level-up moves
 
 TrustanEvosAttacks:
@@ -2687,7 +2693,7 @@ KitsenEvosAttacks:
 	dbw 30, CURSE
 	dbw 36, HYPNOSIS
 	dbw 42, THIEF
-	dbw 48, WIND_RIDE
+	dbw 48, AGILITY
 	dbw 54, DESTINY_BOND
 	dbw 60, FUTURE_SIGHT
 	db 0 ; no more level-up moves

--- a/data/pokemon/evos_attacks_kanto.asm
+++ b/data/pokemon/evos_attacks_kanto.asm
@@ -348,10 +348,10 @@ SquirtleEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, TACKLE
 	dbw 1, TAIL_WHIP
-	dbw 7, ABSORB ; New!
-	dbw 11, WITHDRAW
-	dbw 14, BUBBLEBEAM ; RG proto
-	dbw 17, BRIGHT_MOSS
+	dbw 7, BUBBLE
+	dbw 11, ABSORB ; New!
+	dbw 14, WITHDRAW
+	dbw 17, BUBBLEBEAM ; RG proto
 	dbw 20, COMET_PUNCH ; RG proto
 	dbw 23, RAPID_SPIN
 	dbw 26, MEGA_DRAIN ; New!
@@ -366,10 +366,10 @@ WartortleEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, TACKLE
 	dbw 1, TAIL_WHIP
-	dbw 7, ABSORB ; New!
-	dbw 11, WITHDRAW
-	dbw 14, BUBBLEBEAM ; RG proto
-	dbw 19, BRIGHT_MOSS
+	dbw 7, BUBBLE
+	dbw 11, ABSORB ; New!
+	dbw 14, WITHDRAW
+	dbw 19, BUBBLEBEAM ; RG proto
 	dbw 22, COMET_PUNCH ; RG proto
 	dbw 27, RAPID_SPIN
 	dbw 30, MEGA_DRAIN ; New!
@@ -383,10 +383,10 @@ TotartleEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, TACKLE
 	dbw 1, TAIL_WHIP
-	dbw 7, ABSORB ; New!
-	dbw 11, WITHDRAW
-	dbw 14, BUBBLEBEAM ; RG proto
-	dbw 19, BRIGHT_MOSS
+	dbw 7, BUBBLE
+	dbw 11, ABSORB ; New!
+	dbw 14, WITHDRAW
+	dbw 19, BUBBLEBEAM ; RG proto
 	dbw 22, COMET_PUNCH ; RG proto
 	dbw 27, RAPID_SPIN
 	dbw 30, MEGA_DRAIN ; New!
@@ -424,6 +424,8 @@ ButterfreeEvosAttacks:
 	dbw 30, GUST
 	dbw 35, PSYBEAM
 	dbw 40, SAFEGUARD
+	dbw 45, MEGA_DRAIN ; RG Proto
+	dbw 50, PSYCHIC_M ; RBY TM, KEPiversary
 	db 0 ; no more level-up moves
 
 WeedleEvosAttacks:
@@ -451,6 +453,8 @@ BeedrillEvosAttacks:
 	dbw 30, PURSUIT
 	dbw 35, PIN_MISSILE
 	dbw 40, AGILITY
+	dbw 45, DOUBLE_EDGE ; RBY TM
+	dbw 50, SWORDS_DANCE ; RBY TM, KEP
 	db 0 ; no more level-up moves
 
 GentlarvaEvosAttacks:
@@ -478,6 +482,8 @@ CarapthorEvosAttacks:
 	dbw 30, MEGA_PUNCH
 	dbw 35, SUBSTITUTE
 	dbw 40, SWAGGER
+	dbw 45, SUBMISSION
+	dbw 50, DYNAMICPUNCH
 	db 0 ; no more level-up moves
 
 KotoraEvosAttacks:
@@ -667,13 +673,15 @@ EkansEvosAttacks:
 	dbw 1, WRAP
 	dbw 1, LEER
 	dbw 9, POISON_STING
-	dbw 15, BITE
-	dbw 21, GLARE
-	dbw 27, SCREECH
-	dbw 32, HEADBUTT ; RG proto
-	dbw 37, ACID
-	dbw 43, HAZE
-	dbw 49, TOXIC ; RG proto
+	dbw 13, BITE
+	dbw 19, GLARE
+	dbw 22, ACID
+	dbw 26, HEADBUTT ; RG proto
+	dbw 32, SCREECH
+	dbw 36, HAZE
+	dbw 40, SLUDGE_BOMB ; TM
+	dbw 45, CRUNCH ; Egg move
+	dbw 50, TOXIC ; RG proto
 	db 0 ; no more level-up moves
 
 ArbokEvosAttacks:
@@ -681,13 +689,15 @@ ArbokEvosAttacks:
 	dbw 1, WRAP
 	dbw 1, LEER
 	dbw 9, POISON_STING
-	dbw 15, BITE
-	dbw 21, GLARE
-	dbw 29, SCREECH
-	dbw 34, HEADBUTT ; RG proto
-	dbw 39, ACID
-	dbw 47, HAZE
-	dbw 51, TOXIC ; RG proto
+	dbw 13, BITE
+	dbw 19, GLARE
+	dbw 22, ACID
+	dbw 28, HEADBUTT ; RG proto
+	dbw 34, SCREECH
+	dbw 38, HAZE
+	dbw 44, SLUDGE_BOMB ; TM
+	dbw 49, CRUNCH ; Egg move
+	dbw 54, TOXIC ; RG proto
 	db 0 ; no more level-up moves
 
 PikachuEvosAttacks:
@@ -822,6 +832,7 @@ NidoqueenEvosAttacks:
 	dbw 23, BODY_SLAM
 	dbw 36, ATTRACT ; SW97
 	dbw 43, VITAL_THROW ; Substitute for Superpower
+	dbw 51, EARTHQUAKE ; KEP
 	db 0 ; no more level-up moves
 
 NidoranMEvosAttacks:
@@ -864,6 +875,7 @@ NidokingEvosAttacks:
 	dbw 23, THRASH
 	dbw 36, ATTRACT ; SW97
 	dbw 43, MEGAHORN ; FRLG
+	dbw 51, EARTHQUAKE ; KEP
 	db 0 ; no more level-up moves
 	
 NidoreignEvosAttacks:
@@ -872,9 +884,10 @@ NidoreignEvosAttacks:
 	dbw 1, SPIKE_CANNON
 	dbw 1, POISON_STING
 	dbw 1, TOXIC
-	dbw 23, ROCK_HEAD
+	dbw 23, SKULL_BASH
 	dbw 36, BODY_SLAM
-	dbw 43, SKULL_BASH
+	dbw 43, MOONBLAST
+	dbw 51, SKULL_BASH
 	db 0 ; no more level-up moves
 
 ClefairyEvosAttacks:
@@ -985,7 +998,7 @@ BittybatEvosAttacks:
 	dbw 26, THRASH ; RG proto
 	dbw 31, CONFUSION ; RG proto
 	dbw 35, MEAN_LOOK
-	dbw 41, WIND_RIDE
+	dbw 41, MEGA_DRAIN ; RBY TM
 	dbw 46, HAZE
 	db 0 ; no more level-up moves
 
@@ -1000,7 +1013,7 @@ ZubatEvosAttacks:
 	dbw 28, THRASH ; RG proto
 	dbw 35, CONFUSION ; RG proto
 	dbw 39, MEAN_LOOK
-	dbw 45, WIND_RIDE
+	dbw 45, MEGA_DRAIN ; RBY TM
 	dbw 52, HAZE
 	db 0 ; no more level-up moves
 
@@ -1017,7 +1030,7 @@ GolbatEvosAttacks:
 	dbw 31, THRASH ; RG proto
 	dbw 37, CONFUSION ; RG proto
 	dbw 41, MEAN_LOOK
-	dbw 49, WIND_RIDE
+	dbw 49, MEGA_DRAIN ; RBY TM
 	dbw 56, HAZE
 	db 0 ; no more level-up moves
 
@@ -1026,14 +1039,14 @@ OddishEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, ABSORB
 	dbw 7, SWEET_SCENT
-	dbw 11, BRIGHT_MOSS
+	dbw 11, GROWTH ; SW97
 	dbw 14, POISONPOWDER
 	dbw 16, STUN_SPORE
 	dbw 18, SLEEP_POWDER
 	dbw 23, ACID
 	dbw 28, MEGA_DRAIN ; HGSS
 	dbw 32, MOONLIGHT
-	dbw 36, GROWTH ; SW97
+	dbw 36, TOXIC ; RBY TM
 	dbw 40, PETAL_DANCE
 	dbw 44, MOONBLAST ; XY
 	dbw 49, GIGA_DRAIN ; HGSS
@@ -1045,14 +1058,14 @@ GloomEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, ABSORB
 	dbw 7, SWEET_SCENT
-	dbw 11, BRIGHT_MOSS
+	dbw 11, GROWTH ; SW97
 	dbw 14, POISONPOWDER
 	dbw 16, STUN_SPORE
 	dbw 18, SLEEP_POWDER
 	dbw 25, ACID
 	dbw 30, MEGA_DRAIN ; HGSS
 	dbw 34, MOONLIGHT
-	dbw 40, GROWTH ; SW97
+	dbw 40, TOXIC ; RBY TM
 	dbw 44, PETAL_DANCE
 	dbw 48, MOONBLAST ; XY
 	dbw 55, GIGA_DRAIN ; HGSS
@@ -1072,10 +1085,10 @@ ParasporEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, ABSORB
 	dbw 1, SCRATCH
-	dbw 7, BRIGHT_MOSS
-	dbw 11, STUN_SPORE
-	dbw 14, POISONPOWDER
-	dbw 17, LEECH_LIFE
+	dbw 7, STUN_SPORE
+	dbw 11, POISONPOWDER
+	dbw 14, LEECH_LIFE
+	dbw 17, MEGA_DRAIN ; RBY TM
 	dbw 21, SPORE
 	dbw 25, FURY_SWIPES ; SW97
 	dbw 29, GROWTH
@@ -1089,10 +1102,10 @@ ParasEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, ABSORB ; RG proto
 	dbw 1, SCRATCH
-	dbw 7, BRIGHT_MOSS
-	dbw 11, STUN_SPORE
-	dbw 14, POISONPOWDER
-	dbw 19, LEECH_LIFE
+	dbw 7, STUN_SPORE
+	dbw 11, POISONPOWDER
+	dbw 14, LEECH_LIFE
+	dbw 19, MEGA_DRAIN ; RBY TM
 	dbw 23, SPORE
 	dbw 27, FURY_SWIPES ; SW97
 	dbw 33, GROWTH
@@ -1105,10 +1118,10 @@ ParasectEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, ABSORB ; RG proto
 	dbw 1, SCRATCH
-	dbw 7, BRIGHT_MOSS
-	dbw 11, STUN_SPORE
-	dbw 14, POISONPOWDER
-	dbw 19, LEECH_LIFE
+	dbw 7, STUN_SPORE
+	dbw 11, POISONPOWDER
+	dbw 14, LEECH_LIFE
+	dbw 19, MEGA_DRAIN ; RBY TM
 	dbw 23, SPORE
 	dbw 29, FURY_SWIPES ; SW97
 	dbw 35, GROWTH
@@ -1404,7 +1417,7 @@ PoliwagEvosAttacks:
 	dbbw EVOLVE_LEVEL, 25, POLIWHIRL
 	db 0 ; no more evolutions
 	dbw 1, BUBBLE
-	dbw 1, WATER_SPORT
+	dbw 1, SUPERSONIC ; RG proto
 	dbw 7, HYPNOSIS
 	dbw 13, WATER_GUN
 	dbw 19, DOUBLESLAP
@@ -1422,7 +1435,7 @@ PoliwhirlEvosAttacks:
 	dbbw EVOLVE_ITEM, HEART_STONE, POLITOED
 	db 0 ; no more evolutions
 	dbw 1, BUBBLE
-	dbw 1, WATER_SPORT
+	dbw 1, SUPERSONIC ; RG proto
 	dbw 7, HYPNOSIS
 	dbw 13, WATER_GUN
 	dbw 19, DOUBLESLAP
@@ -1442,7 +1455,7 @@ PoliwrathEvosAttacks:
 	dbw 1, DOUBLESLAP
 	dbw 1, LOW_KICK ; SW97
 	dbw 35, SUBMISSION
-	dbw 43, STRONG_ARM
+	dbw 43, DYNAMICPUNCH ; TM, later game learnsets
 	dbw 51, MIND_READER
 	db 0 ; no more level-up moves
 
@@ -1554,7 +1567,7 @@ BellsproutEvosAttacks:
 	dbw 27, FALSE_SWIPE ; SW97
 	dbw 33, SWEET_SCENT
 	dbw 37, RAZOR_LEAF
-	dbw 42, UPROOT
+	dbw 42, COUNTER ; Anime reference!
 	dbw 48, SLAM
 	db 0 ; no more level-up moves
 
@@ -1572,7 +1585,7 @@ WeepinbellEvosAttacks:
 	dbw 29, FALSE_SWIPE ; SW97
 	dbw 35, SWEET_SCENT
 	dbw 41, RAZOR_LEAF
-	dbw 46, UPROOT
+	dbw 46, COUNTER ; Anime reference!
 	dbw 52, SLAM
 	db 0 ; no more level-up moves
 
@@ -1584,6 +1597,7 @@ VictreebelEvosAttacks:
 	dbw 1, RAZOR_LEAF
 	dbw 40, SLEEP_POWDER
 	dbw 48, GIGA_DRAIN ; TM, to match Bellignan
+	dbw 52, SOLARBEAM ; KEP, transferred from Bellignan
 	db 0 ; no more level-up moves
 
 BellignanEvosAttacks:
@@ -1594,6 +1608,7 @@ BellignanEvosAttacks:
 	dbw 1, ACID
 	dbw 40, LOVELY_KISS
 	dbw 48, SLUDGE_BOMB
+	dbw 52, SUBMISSION
 	db 0 ; no more level-up moves
 
 TentacoolEvosAttacks:
@@ -1701,7 +1716,7 @@ GeodudeEvosAttacks:
 	dbw 37, EARTHQUAKE
 	dbw 41, EXPLOSION
 	dbw 46, ROCK_HEAD
-	dbw 52, STRONG_ARM
+	dbw 52, DOUBLE_EDGE ; RG proto
 	dbw 58, FISSURE ; RG proto
 	db 0 ; no more level-up moves
 
@@ -1800,7 +1815,7 @@ BalumbaEvosAttacks:
 	dbw 36, CHARM
 	dbw 42, WHIRLWIND
 	dbw 48, DAZZLING_GLEAM
-	dbw 54, WIND_RIDE
+	dbw 54, EXPLOSION
 	db 0
 
 SlowpokeEvosAttacks:
@@ -2055,7 +2070,7 @@ SeelEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, HEADBUTT
 	dbw 1, GROWL
-	dbw 7, WATER_SPORT
+	dbw 7, WATER_GUN ; RBY TM
 	dbw 12, POWDER_SNOW ; SW97
 	dbw 16, ICY_WIND ; FRLG
 	dbw 21, REST
@@ -2071,7 +2086,7 @@ DewgongEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, HEADBUTT
 	dbw 1, GROWL
-	dbw 7, WATER_SPORT
+	dbw 7, WATER_GUN ; RBY TM
 	dbw 12, POWDER_SNOW ; SW97
 	dbw 16, ICY_WIND ; FRLG
 	dbw 21, REST
@@ -2467,6 +2482,7 @@ LickitungEvosAttacks:
 	dbw 36, SLAM
 	dbw 42, SCREECH
 	dbw 48, AMNESIA ; SW97
+	dbw 53, BODY_SLAM; RBY TM
 	db 0 ; no more level-up moves
 	
 LickilickyEvosAttacks:
@@ -2482,6 +2498,7 @@ LickilickyEvosAttacks:
 	dbw 38, SLAM
 	dbw 44, SCREECH
 	dbw 52, AMNESIA ; SW97
+	dbw 57, BODY_SLAM; RBY TM
 	db 0 ; no more level-up moves
 	
 LickilordEvosAttacks: ; SW97 learnset + some poison stuff
@@ -2541,8 +2558,8 @@ RhyhornEvosAttacks:
 	dbw 19, FURY_ATTACK
 	dbw 24, ENDURE ; SW97
 	dbw 28, SCARY_FACE
-	dbw 32, TAKE_DOWN
-	dbw 37, UPROOT
+	dbw 32, MAGNITUDE ; Egg move
+	dbw 37, TAKE_DOWN
 	dbw 43, ROCK_HEAD
 	dbw 49, HORN_DRILL
 	dbw 55, EARTHQUAKE
@@ -2558,8 +2575,8 @@ RhydonEvosAttacks:
 	dbw 19, FURY_ATTACK
 	dbw 24, ENDURE ; SW97
 	dbw 28, SCARY_FACE
-	dbw 32, TAKE_DOWN
-	dbw 37, UPROOT
+	dbw 32, MAGNITUDE ; Egg move
+	dbw 37, TAKE_DOWN
 	dbw 43, ROCK_HEAD
 	dbw 49, HORN_DRILL
 	dbw 55, EARTHQUAKE
@@ -2603,7 +2620,7 @@ BurgelaEvosAttacks:
 	dbw 19, VINE_WHIP
 	dbw 24, BIND
 	dbw 28, MEGA_DRAIN
-	dbw 33, UPROOT
+	dbw 33, SYNTHESIS ; NYPC
 	dbw 38, STUN_SPORE
 	dbw 42, SLAM
 	dbw 46, GROWTH
@@ -2621,7 +2638,7 @@ TangelaEvosAttacks:
 	dbw 19, VINE_WHIP
 	dbw 26, BIND
 	dbw 30, MEGA_DRAIN
-	dbw 35, UPROOT
+	dbw 35, SYNTHESIS ; NYPC
 	dbw 42, STUN_SPORE
 	dbw 46, SLAM
 	dbw 50, GROWTH
@@ -2637,12 +2654,13 @@ TangrowthEvosAttacks:
 	dbw 19, VINE_WHIP
 	dbw 26, BIND
 	dbw 30, MEGA_DRAIN
-	dbw 35, UPROOT
+	dbw 35, SYNTHESIS ; NYPC
 	dbw 42, STUN_SPORE
 	dbw 44, ANCIENTPOWER
 	dbw 48, SLAM
 	dbw 52, GROWTH
 	dbw 60, GIGA_DRAIN ; Later gen level-up & TM
+	dbw 65, SLUDGE_BOMB ; PLA
 	db 0 ; no more level-up moves
 	
 JungelaEvosAttacks:
@@ -2674,7 +2692,7 @@ KangaskhanEvosAttacks:
 	dbw 37, DIZZY_PUNCH
 	dbw 43, ENDURE
 	dbw 49, MEGA_PUNCH
-	dbw 55, STRONG_ARM
+	dbw 55, OUTRAGE ; LGPE
 	dbw 61, REVERSAL
 	db 0 ; no more level-up moves
 
@@ -2883,6 +2901,7 @@ ScytherEvosAttacks:
 	dbw 42, SWORDS_DANCE
 	dbw 48, DOUBLE_TEAM
 	dbw 54, CROSS_CUTTER
+	dbw 60, RAZOR_WIND
 	db 0 ; no more level-up moves
 	
 KleavorEvosAttacks:
@@ -2894,11 +2913,12 @@ KleavorEvosAttacks:
 	dbw 17, FALSE_SWIPE
 	dbw 22, FURY_CUTTER ; SW97
 	dbw 26, AGILITY
-	dbw 30, ROCK_SLASH
+	dbw 30, ROCK_HEAD
 	dbw 36, SLASH
 	dbw 42, SWORDS_DANCE
 	dbw 48, DOUBLE_TEAM
 	dbw 54, CROSS_CUTTER
+	dbw 60, ROCK_SLASH
 	db 0 ; no more level-up moves
 
 JynxEvosAttacks:
@@ -3017,7 +3037,7 @@ PinsirEvosAttacks:
 	dbw 43, SWORDS_DANCE
 	dbw 49, GUILLOTINE
 	dbw 55, SLASH ; SW97, RBY
-	dbw 60, STRONG_ARM
+	dbw 60, THRASH ; LGPE
 	db 0 ; no more level-up moves
 
 TriculesEvosAttacks:
@@ -3033,7 +3053,7 @@ TriculesEvosAttacks:
 	dbw 43, SWORDS_DANCE
 	dbw 49, GUILLOTINE
 	dbw 55, SLASH ; SW97, RBY
-	dbw 60, STRONG_ARM
+	dbw 60, THRASH ; LGPE
 	dbw 65, MEGAHORN ; due to its connection to Heracross (and giant horn)
 	db 0 ; no more level-up moves
 
@@ -3318,15 +3338,17 @@ DecillaEvosAttacks:
 	dbw 1, TACKLE
 	dbw 1, GROWL
 	dbw 1, MEGAPHONE
-	dbw 8, SUBSTITUTE
-	dbw 15, SCREECH
-	dbw 22, ROCK_THROW
-	dbw 29, DRAGONBREATH
-	dbw 36, ROAR
-	dbw 43, ROCK_SLIDE
-	dbw 50, CURSE
-	dbw 57, ROCK_SLASH
-	dbw 64, HYPER_BEAM
+	dbw 7, SUBSTITUTE
+	dbw 14, SCREECH
+	dbw 21, ROCK_THROW
+	dbw 28, DRAGONBREATH
+	dbw 35, ROAR
+	dbw 40, RECOVER
+	dbw 47, ROCK_SLIDE
+	dbw 54, CURSE
+	dbw 59, SPIKES
+	dbw 66, ROCK_SLASH
+	dbw 73, HYPER_BEAM
 	db 0 ; no more level-up moves
 
 GawarhedEvosAttacks:
@@ -3334,16 +3356,18 @@ GawarhedEvosAttacks:
 	dbw 1, TACKLE
 	dbw 1, GROWL
 	dbw 1, MEGAPHONE
-	dbw 8, SUBSTITUTE
-	dbw 15, SCREECH
-	dbw 22, ROCK_THROW
-	dbw 29, DRAGONBREATH
-	dbw 36, ROAR
+	dbw 7, SUBSTITUTE
+	dbw 14, SCREECH
+	dbw 21, ROCK_THROW
+	dbw 28, DRAGONBREATH
+	dbw 35, ROAR
 	dbw 40, OUTRAGE
-	dbw 45, ROCK_SLIDE
-	dbw 54, CURSE
-	dbw 63, ROCK_SLASH
-	dbw 70, HYPER_BEAM
+	dbw 42, RECOVER
+	dbw 49, ROCK_SLIDE
+	dbw 56, CURSE
+	dbw 63, SPIKES
+	dbw 70, ROCK_SLASH
+	dbw 77, HYPER_BEAM
 	db 0 ; no more level-up moves
 
 MunchlaxEvosAttacks:
@@ -3531,12 +3555,14 @@ MewtwoEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, CONFUSION
 	dbw 1, DISABLE
-	dbw 11, BARRIER
-	dbw 22, SWIFT
-	dbw 33, PSYCH_UP
-	dbw 44, FUTURE_SIGHT
-	dbw 55, MIST
-	dbw 66, PSYCHIC_M
+	dbw 1, SYNCHRONIZE
+	dbw 1, BARRIER
+	dbw 11, SWIFT
+	dbw 22, PSYCH_UP
+	dbw 33, FUTURE_SIGHT
+	dbw 44, MIST
+	dbw 55, PSYCHIC_M
+	dbw 66, SHADOW_BALL ; TM, Mewtwo Strikes Back
 	dbw 77, AMNESIA
 	dbw 88, RECOVER
 	dbw 99, SAFEGUARD
@@ -3545,6 +3571,7 @@ MewtwoEvosAttacks:
 MewEvosAttacks:
 	db 0 ; no more evolutions
 	dbw 1, POUND
+	dbw 1, SYNCHRONIZE
 	dbw 10, TRANSFORM
 	dbw 20, MEGA_PUNCH
 	dbw 30, METRONOME


### PR DESCRIPTION
Did a second pass on the Level-up movesets, both to remove the Nihon HMs and tune up some mons that had more lacking movesets. Hope this overall makes the Pokemon feel more alive and enjoyable!